### PR TITLE
Add GSSAPIContext::exportCredentials() and importCredentials()

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -62,6 +62,7 @@ if test "$PHP_KRB5" != "no" -o "$PHP_KRB5KADM" != "no"; then
 
 	AC_CHECK_FUNCS(krb5_free_string)
 	AC_CHECK_FUNCS(gss_acquire_cred_from)
+	AC_CHECK_FUNCS(gss_export_cred)
 	AC_CHECK_FUNCS(krb5_chpw_message)
 	AC_CHECK_FUNCS(krb5_principal_get_realm)
 	AC_CHECK_FUNCS(krb5_get_init_creds_opt_set_expire_callback)

--- a/config.m4
+++ b/config.m4
@@ -2,11 +2,6 @@ PHP_ARG_WITH(krb5, for kerberos support,
  [  --with-krb5             Include generic kerberos5/GSSAPI support]
  )
 
-PHP_ARG_WITH(krb5config, path to krb5config tool,
- [  --with-krb5config       Path to krb5config tool],
- no, no
- )
-
 PHP_ARG_WITH(krb5kadm, for kerberos KADM5 support,
  [  --with-krb5kadm[=S]      Include KADM5 Kerberos Administration Support - MIT only],
  no, no
@@ -14,40 +9,44 @@ PHP_ARG_WITH(krb5kadm, for kerberos KADM5 support,
 
 if test "$PHP_KRB5" != "no" -o "$PHP_KRB5KADM" != "no"; then
 
-
-	if test "$PHP_KRB5CONFIG" == "no"; then
-		PHP_KRB5CONFIG=`which krb5-config`
+	AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+	if test "${PKG_CONFIG}" = "no"; then
+		AC_MSG_ERROR([pkg-config is required to build the krb5 extension])
 	fi
 
-	AC_MSG_CHECKING([whether we have krb5config])
-
-	if test -x $PHP_KRB5CONFIG; then
-		AC_MSG_RESULT($PHP_KRB5CONFIG)
+	AC_MSG_CHECKING([for mit-krb5-gssapi via pkg-config])
+	if ${PKG_CONFIG} --exists mit-krb5-gssapi mit-krb5; then
+		AC_MSG_RESULT([yes])
 	else
-		AC_MSG_ERROR([no])
-		exit
+		AC_MSG_ERROR([mit-krb5-gssapi or mit-krb5 not found -- install libkrb5-dev or equivalent])
 	fi
-
-
 
 	if test "$PHP_KRB5KADM" != "no"; then
-		KRB5_LDFLAGS=`$PHP_KRB5CONFIG --libs krb5 gssapi kadm-client`
-		KRB5_CFLAGS=`$PHP_KRB5CONFIG --cflags krb5 gssapi kadm-client`
+		dnl Try kadm-client via pkg-config; fall back to the MIT library name.
+		if ${PKG_CONFIG} --exists kadm-client 2>/dev/null; then
+			KRB5_LDFLAGS=`${PKG_CONFIG} --libs-only-L mit-krb5-gssapi mit-krb5 kadm-client`
+			KRB5_LIBS=`${PKG_CONFIG} --libs-only-l mit-krb5-gssapi mit-krb5 kadm-client`
+			KRB5_CFLAGS=`${PKG_CONFIG} --cflags mit-krb5-gssapi mit-krb5 kadm-client`
+		else
+			KRB5_LDFLAGS=`${PKG_CONFIG} --libs-only-L mit-krb5-gssapi mit-krb5`
+			KRB5_LIBS="`${PKG_CONFIG} --libs-only-l mit-krb5-gssapi mit-krb5` -lkadm5clnt_mit"
+			KRB5_CFLAGS=`${PKG_CONFIG} --cflags mit-krb5-gssapi mit-krb5`
+		fi
 	else
-		KRB5_LDFLAGS=`$PHP_KRB5CONFIG --libs krb5 gssapi`
-		KRB5_CFLAGS=`$PHP_KRB5CONFIG --cflags krb5 gssapi`
+		KRB5_LDFLAGS=`${PKG_CONFIG} --libs-only-L mit-krb5-gssapi mit-krb5`
+		KRB5_LIBS=`${PKG_CONFIG} --libs-only-l mit-krb5-gssapi mit-krb5`
+		KRB5_CFLAGS=`${PKG_CONFIG} --cflags mit-krb5-gssapi mit-krb5`
 	fi
 
 	AC_MSG_CHECKING([for required linker flags])
-	AC_MSG_RESULT($KRB5_LDFLAGS)
+	AC_MSG_RESULT([$KRB5_LDFLAGS $KRB5_LIBS])
 
 	AC_MSG_CHECKING([for required compiler flags])
-	AC_MSG_RESULT($KRB5_CFLAGS)
+	AC_MSG_RESULT([$KRB5_CFLAGS])
 
-	KRB5_VERSION=`$PHP_KRB5CONFIG --version`
-
+	KRB5_VERSION=`${PKG_CONFIG} --modversion mit-krb5-gssapi`
 	AC_MSG_CHECKING([for kerberos library version])
-	AC_MSG_RESULT($KRB5_VERSION)
+	AC_MSG_RESULT([$KRB5_VERSION])
 	AC_DEFINE_UNQUOTED(KRB5_VERSION, ["$KRB5_VERSION"], [Kerberos library version])
 
 	SOURCE_FILES="krb5.c negotiate_auth.c gssapi.c channel.c"
@@ -59,6 +58,7 @@ if test "$PHP_KRB5" != "no" -o "$PHP_KRB5KADM" != "no"; then
 
 	CFLAGS="-Wall ${CFLAGS} ${KRB5_CFLAGS}"
 	LDFLAGS="${LDFLAGS} ${KRB5_LDFLAGS}"
+	LIBS="${LIBS} ${KRB5_LIBS}"
 
 	AC_CHECK_FUNCS(krb5_free_string)
 	AC_CHECK_FUNCS(gss_acquire_cred_from)

--- a/gssapi.c
+++ b/gssapi.c
@@ -21,6 +21,9 @@
 **/
 
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
 #include "php.h"
 #include "php_krb5.h"
 
@@ -94,6 +97,11 @@ ZEND_BEGIN_ARG_INFO_EX(krb5_GSSAPIContext_unwrapArgs, 0, 0, 2)
 	ZEND_ARG_INFO(1, output)
 ZEND_END_ARG_INFO()
 
+#ifdef HAVE_GSS_EXPORT_CRED
+ZEND_BEGIN_ARG_INFO_EX(krb5_GSSAPIContext_importCredentials, 0, 0, 1)
+	ZEND_ARG_INFO(0, token)
+ZEND_END_ARG_INFO()
+#endif
 
 PHP_METHOD(GSSAPIContext, registerAcceptorIdentity);
 PHP_METHOD(GSSAPIContext, acquireCredentials);
@@ -105,6 +113,10 @@ PHP_METHOD(GSSAPIContext, verifyMic);
 PHP_METHOD(GSSAPIContext, wrap);
 PHP_METHOD(GSSAPIContext, unwrap);
 PHP_METHOD(GSSAPIContext, getTimeRemaining);
+#ifdef HAVE_GSS_EXPORT_CRED
+PHP_METHOD(GSSAPIContext, exportCredentials);
+PHP_METHOD(GSSAPIContext, importCredentials);
+#endif
 
 static zend_function_entry krb5_gssapi_context_functions[] = {
 	PHP_ME(GSSAPIContext, registerAcceptorIdentity, krb5_GSSAPIContext_registerAcceptorIdentity, ZEND_ACC_PUBLIC)
@@ -117,6 +129,10 @@ static zend_function_entry krb5_gssapi_context_functions[] = {
 	PHP_ME(GSSAPIContext, wrap,                     krb5_GSSAPIContext_wrapArgs,                 ZEND_ACC_PUBLIC)
 	PHP_ME(GSSAPIContext, unwrap,                   krb5_GSSAPIContext_unwrapArgs,               ZEND_ACC_PUBLIC)
 	PHP_ME(GSSAPIContext, getTimeRemaining,         krb5_GSSAPIContext_none,                     ZEND_ACC_PUBLIC)
+#ifdef HAVE_GSS_EXPORT_CRED
+	PHP_ME(GSSAPIContext, exportCredentials,        krb5_GSSAPIContext_none,                     ZEND_ACC_PUBLIC)
+	PHP_ME(GSSAPIContext, importCredentials,        krb5_GSSAPIContext_importCredentials,        ZEND_ACC_PUBLIC)
+#endif
 	PHP_FE_END
 };
 
@@ -1006,3 +1022,64 @@ PHP_METHOD(GSSAPIContext, unwrap)
 	status = gss_release_buffer(&minor_status, &output);
 	ASSERT_GSS_SUCCESS(status,minor_status,);
 } /* }}} */
+
+#ifdef HAVE_GSS_EXPORT_CRED
+/* {{{ proto string GSSAPIContext::exportCredentials( )
+   Exports the current credentials to an opaque token that can be stored or passed to another process */
+PHP_METHOD(GSSAPIContext, exportCredentials)
+{
+	OM_uint32 status = 0;
+	OM_uint32 minor_status = 0;
+	gss_buffer_desc token;
+	krb5_gssapi_context_object *context = KRB5_THIS_GSSAPI_CONTEXT;
+
+	memset(&token, 0, sizeof(token));
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	if (context->creds == GSS_C_NO_CREDENTIAL) {
+		zend_throw_exception(NULL, "No credentials to export", 0 TSRMLS_CC);
+		return;
+	}
+
+	status = gss_export_cred(&minor_status, context->creds, &token);
+	ASSERT_GSS_SUCCESS(status, minor_status,);
+
+	_RETVAL_STRINGL(token.value, token.length);
+
+	status = gss_release_buffer(&minor_status, &token);
+	ASSERT_GSS_SUCCESS(status, minor_status,);
+} /* }}} */
+
+/* {{{ proto bool GSSAPIContext::importCredentials( string $token )
+   Imports credentials from a token previously created by exportCredentials() */
+PHP_METHOD(GSSAPIContext, importCredentials)
+{
+	OM_uint32 status = 0;
+	OM_uint32 minor_status = 0;
+	gss_buffer_desc token;
+	gss_cred_id_t new_creds = GSS_C_NO_CREDENTIAL;
+	krb5_gssapi_context_object *context = KRB5_THIS_GSSAPI_CONTEXT;
+	strsize_t token_len = 0;
+
+	memset(&token, 0, sizeof(token));
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s",
+			&(token.value), &token_len) == FAILURE) {
+		RETURN_FALSE;
+	}
+	token.length = token_len;
+
+	status = gss_import_cred(&minor_status, &token, &new_creds);
+	ASSERT_GSS_SUCCESS(status, minor_status,);
+
+	if (context->creds != GSS_C_NO_CREDENTIAL) {
+		gss_release_cred(&minor_status, &(context->creds));
+	}
+	context->creds = new_creds;
+
+	RETURN_TRUE;
+} /* }}} */
+#endif

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,0 +1,75 @@
+--TEST--
+Testing for credential export and import
+--SKIPIF--
+<?php
+if(!file_exists(dirname(__FILE__) . '/config.php')) { echo "skip config missing"; return; }
+if(!include(dirname(__FILE__) . '/config.php')) return;
+if(!method_exists('GSSAPIContext', 'exportCredentials')) { echo "skip gss_export_cred not available"; return; }
+?>
+--FILE--
+<?php
+include(dirname(__FILE__) . '/config.php');
+$client = new KRB5CCache();
+if($use_config) {
+	$client->setConfig(dirname(__FILE__) . '/krb5.ini');
+}
+
+$client->initPassword($client_principal, $client_password, array('forwardable' => true, 'proxiable' => true));
+
+$server = new KRB5CCache();
+if($use_config) {
+	$server->setConfig(dirname(__FILE__) . '/krb5.ini');
+}
+
+$server->initKeytab($server_principal, $server_keytab);
+
+$cgssapi = new GSSAPIContext();
+$sgssapi = new GSSAPIContext();
+
+$cgssapi->acquireCredentials($client);
+$sgssapi->acquireCredentials($server);
+
+$token = '';
+$token2 = '';
+$principal = '';
+$ret_flags = 0;
+$time_rec = 0;
+$deleg = new KRB5CCache();
+
+// Establish a context with delegation to obtain delegated credentials
+var_dump($cgssapi->initSecContext($server_principal, null, GSS_C_DELEG_FLAG, null, $token));
+var_dump($sgssapi->acceptSecContext($token, $token2, $principal, $ret_flags, $time_rec, $deleg));
+var_dump(count($deleg->getEntries()));
+
+// Acquire credentials from the delegated ccache, then export them
+$dgssapi = new GSSAPIContext();
+$dgssapi->acquireCredentials($deleg, $principal, GSS_C_INITIATE);
+
+$exported = $dgssapi->exportCredentials();
+var_dump(is_string($exported) && strlen($exported) > 0);
+
+// Import the exported credentials into a fresh context and use them
+$igssapi = new GSSAPIContext();
+var_dump($igssapi->importCredentials($exported));
+
+$s2gssapi = new GSSAPIContext();
+$s2gssapi->acquireCredentials($server);
+
+$token = '';
+$token2 = '';
+$principal2 = '';
+
+var_dump($igssapi->initSecContext($server_principal, null, null, null, $token));
+var_dump($s2gssapi->acceptSecContext($token, $token2, $principal2, $ret_flags, $time_rec, $deleg));
+var_dump($principal2 === $principal);
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+int(1)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/config.php.dist
+++ b/tests/config.php.dist
@@ -22,6 +22,6 @@ if(file_exists(dirname(__FILE__) . '/krb5.ini')) {
 	$use_config = true;
 }
 
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT);
+error_reporting(E_ALL & ~E_DEPRECATED);
 return true;
 ?>


### PR DESCRIPTION
This PR adds two small preparatory fixes (PHP8 compatibility for tests, switching config.m4 to use pkg-config instead of krb5-config for better compatibility with distros like Debian/Gentoo, which use `--as-needed` by default), followed by the "real" commit which adds support for:

`GSSAPIContext::exportCredentials()`
`GSSAPIContext::importCredentials()`

Corresponding to `gssapi`s:
`gss_export_cred()`
`gss_import_cred()`

which allows credentials to be serialised and restored across process boundaries/cached/etc.

As far as I can tell, these functions were introduced in MIT Kerberos release 1.11 (December 17, 2012) and Heimdal version 1.6 (January 2013).