### PR TITLE
config.m4: also add KRB5_LIBS to LDFLAGS for the extension link

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -85,7 +85,7 @@ if test "$PHP_KRB5" != "no" -o "$PHP_KRB5KADM" != "no"; then
 	fi
 
 	CFLAGS="-Wall ${CFLAGS} ${KRB5_CFLAGS}"
-	LDFLAGS="${LDFLAGS} ${KRB5_LDFLAGS}"
+	LDFLAGS="${LDFLAGS} ${KRB5_LDFLAGS} ${KRB5_LIBS}"
 	LIBS="${LIBS} ${KRB5_LIBS}"
 
 	AC_CHECK_FUNCS(krb5_free_string)


### PR DESCRIPTION
4a2f6d0 switched from krb5-config to pkg-config and used --libs-only-L and --libs-only-l to split flags cleanly: -L paths into KRB5_LDFLAGS, -l libraries into KRB5_LIBS.  KRB5_LIBS was then added only to LIBS so that AC_CHECK_FUNCS sees the libraries after the test object (safe with --as-needed).

However, the PHP shared extension link command uses $(LDFLAGS) but not $(LIBS).  Before the refactor, krb5-config --libs returned both -L and -l flags together into KRB5_LDFLAGS, so they all reached $(LDFLAGS) and the extension linked correctly.  After the split, the -l flags landed only in LIBS and were silently dropped from the extension link, leaving GSS_C_NT_HOSTBASED_SERVICE and other GSSAPI symbols undefined at load time.

Fix by adding KRB5_LIBS to LDFLAGS as well as LIBS.  LIBS retains the -l flags for AC_CHECK_FUNCS (after the test object, --as-needed safe); LDFLAGS gains them back for the extension link, restoring the behaviour that krb5-config provided before 4a2f6d0.